### PR TITLE
update setup.py and copyright dates

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,7 +1,7 @@
 mmpdb - matched molecular pair database generation and analysis
 
 
-Copyright (c) 2015-2017 F. Hoffmann-La Roche Ltd., distributed under the
+Copyright (c) 2015-2019 F. Hoffmann-La Roche Ltd., distributed under the
 3-clause BSD license license, below.
 
 Portions may be copyright (c) 2012-2013 by GlaxoSmithKline Research &
@@ -23,7 +23,7 @@ license. These are the files peewee.py and playhouse/*.py.
 Unless otherwise noted, all files in this directory and all
 subdirectories are distributed under the following license:
 
-Copyright (c) 2015-2017, F. Hoffmann-La Roche Ltd.
+Copyright (c) 2015-2019, F. Hoffmann-La Roche Ltd.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ in version 2 were:
 ## Copyright
 
 
-The mmpdb package is copyright 2015-2017 by F. Hoffmann-La
+The mmpdb package is copyright 2015-2018 by F. Hoffmann-La
 Roche Ltd and distributed under the 3-clause BSD license. See [LICENSE](LICENSE)
 for details.
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # mmpdb - matched molecular pair database generation and analysis
 #
-# Copyright (c) 2015-2017, F. Hoffmann-La Roche Ltd.
+# Copyright (c) 2015-2019, F. Hoffmann-La Roche Ltd.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -32,12 +32,19 @@
 
 from setuptools import setup
 
+with open("README.md") as f:
+    long_description = f.read()
+
 setup(
     name="mmpdb",
     version="2.2",
     description="A package to identify matched molecular pairs and use them to predict property changes",
     author="Andrew Dalke",
     author_email="dalke@dalkescientific.com",
+    maintainer="Christian Kramer",
+    maintainer_email="rdkit-discuss@lists.sourceforge.net",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     url="https://github.com/rdkit/mmpdb",
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
I want to update PyPI, the Python Package Index, for version 2.2. This lets people install or update mmpdb using "pip install mmpdb".

I added some changes to the setup.py so that Christian is listed as the maintainer, with the maintainer email as the RDKit mailing list.

I added the content of README.md for the "long description", which PyPI uses for its display.

I extended the copyright date from 2017 to 2019.

You can see the result on the test PyPI server, at https://test.pypi.org/project/mmpdb/ .

Compare it with https://pypi.org/project/mmpdb/

Let me know if there's anything else to update.