### PR TITLE
fix jupyter/ipython compatibility

### DIFF
--- a/mmpdblib/_compat.py
+++ b/mmpdblib/_compat.py
@@ -67,7 +67,7 @@ else:
 
     # gzip requires a binary file
     binary_stdin = sys.stdin.buffer
-    binary_stdout = sys.stdout.buffer
+    binary_stdout = getattr(sys.stdout, 'buffer', sys.stdout)
     
     # Lazy map is the default
     imap = map


### PR DESCRIPTION
In jupyter (or ipython), `from mmpdblib import commandline` gives the following error:
```
AttributeError:` 'OutStream' object has no attribute 'buffer'
```
This pull request resolves this error