### PR TITLE
Compatibility with Python 3.10

### DIFF
--- a/mmpdblib/peewee.py
+++ b/mmpdblib/peewee.py
@@ -135,7 +135,10 @@ PY3 = sys.version_info[0] == 3
 PY26 = sys.version_info[:2] == (2, 6)
 if PY3:
     import builtins
-    from collections import Callable
+    try:
+        from collections.abc import Callable
+    except ImportError:
+        from collections import Callable
     from functools import reduce
     callable = lambda c: isinstance(c, Callable)
     unicode_type = str


### PR DESCRIPTION
I was unable to use SQLite functionality of mmpdb in Python 3.10 due to removal of the deprecated Callable from collections. This pull request adds a try except block to first attempt import of Callable from collections.abc, and if not present, falls back on the older Callable in collections for earlier versions of Python.