### PR TITLE
Use version-independent *[H] in fragment_molecule_on_explicit_hydrogens()

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -58,5 +58,7 @@ include tests/test_data_2018.mmpdb
 include tests/test_data_2019.mmpdb
 include tests/test_frag2smarts.py
 include tests/test_fragment.py
+include tests/test_fragment_algorithm.py
 include tests/test_index.py
+include tests/test_loadprops.py
 include tests/two_tabs.smi

--- a/mmpdblib/fragment_algorithm.py
+++ b/mmpdblib/fragment_algorithm.py
@@ -830,6 +830,9 @@ def get_hydrogen_fragmentations(smiles, num_heavies):
 
 _hydrogen_cut_pat = Chem.MolFromSmarts("[!#1]-[0#1v1!+!-]")
 
+# Get '*[H]' (or equivalent) from RDKit to make sure it's version-independent.
+_wild_h = Chem.MolToSmiles(Chem.MolFromSmiles('*[H]', sanitize=False))
+
 def fragment_molecule_on_explicit_hydrogens(smiles):
     num_heavies = get_num_heavies_from_smiles(smiles)
     smiles_with_H = Chem.CanonSmiles(smiles)
@@ -847,9 +850,9 @@ def fragment_molecule_on_explicit_hydrogens(smiles):
         left, mid, right = new_smiles.partition(".")
         assert mid == ".", new_smiles
 
-        if left == "[*][H]":  # Hard-coded
+        if left == _wild_h:
             cut_smiles = right
-        elif right == "[*][H]":
+        elif right == _wild_h:
             cut_smiles = left
         else:
             raise AssertionError("did not split hydrogen correctly: %r %r"

--- a/tests/test_fragment_algorithm.py
+++ b/tests/test_fragment_algorithm.py
@@ -1,0 +1,19 @@
+import unittest
+
+from rdkit import Chem
+
+from mmpdblib import fragment_algorithm
+from test_fragment import FIX
+
+
+class TestFragmentAlgorithm(unittest.TestCase):
+
+    def test_fragment_molecule_on_explicit_hydrogens(self):
+        smiles = '[H][CH2]O[H]'
+        frags = fragment_algorithm.fragment_molecule_on_explicit_hydrogens(smiles)
+        keys = [FIX(frag.get_unique_key()) for frag in frags]
+        self.assertEqual(keys, ['0.*[H].*CO', '0.*[H].*OC'])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Since 2018, RDKit generates "\*" instead of "[\*]" for wildcard atoms, but fragment_molecule_on_explicit_hydrogens() was comparing RDKit-generated SMILES against the hard-coded string "[\*][H]", which led to AssertionError "did not split hydrogen correctly".

This commit replaces the hard-coded string with one produced by Chem.MolFromSmiles(). (I did not change the string that is passed to the Fragmentation constructor, since it didn't seem necessary.)

(Also added test_loadprops.py to the manifest; I forgot tot do so when I added that test years ago!)